### PR TITLE
Implement search and lazy clode

### DIFF
--- a/clode/clode.py
+++ b/clode/clode.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from .command_line import clone, code, CommandException, get_clone_output
+from .command_line import git_clone, code, CommandException, get_clone_output
 import re
 from colorama import Fore
 
@@ -40,7 +40,7 @@ def clode(
     clone_success = False
     try:
         print(f"Cloning {Fore.YELLOW}{url}{Fore.LIGHTBLACK_EX}")
-        clone(url, output_folder)
+        git_clone(url, output_folder)
         clone_success = True
     except CommandException as e:
         print(Fore.RED + "git clone failed" + Fore.RESET)

--- a/clode/errors.py
+++ b/clode/errors.py
@@ -1,0 +1,2 @@
+class NoUsernameProvidedException(Exception):
+    pass

--- a/clode/search.py
+++ b/clode/search.py
@@ -1,0 +1,50 @@
+import re
+import inquirer as inq
+
+from colorama import Fore
+
+from .errors import NoUsernameProvidedException
+
+from .clode import DEFAULT_CLODE_USERNAME
+
+from .command_line import gh_search_repository
+
+
+def search_repository(query: str) -> str:
+    repositories: list[str] = gh_search_repository(query)
+
+    if len(repositories) == 0:
+        print(Fore.RED + "No repositories found" + Fore.RESET)
+        exit()
+    if len(repositories) == 1:
+        return repositories[0]
+
+    question = inq.List(
+        "repo", message="Select repository to clone", choices=repositories
+    )
+    answers = inq.prompt([question])
+    if answers is None:
+        raise KeyboardInterrupt
+
+    return answers["repo"]
+
+
+LAZY_REPOSITORY_PATTERN = re.compile(r"^([\w.-]+\/)?[\w.-]+$")
+
+
+def resolve_lazy(repository: str) -> str:
+    if not re.match(LAZY_REPOSITORY_PATTERN, repository):
+        print(Fore.RED + "Invalid lazy pattern" + Fore.RESET)
+        exit()
+
+    owner: str
+    name: str
+    if "/" in repository:
+        owner, name = repository.split("/")
+    else:
+        if not DEFAULT_CLODE_USERNAME:
+            raise NoUsernameProvidedException()
+        owner = DEFAULT_CLODE_USERNAME
+        name = repository
+
+    return search_repository(f"owner:{owner} in:name fork:true sort:updated {name}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ universal = 1
 [options]
 install_requires =
     colorama
+    inquirer
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     license="MIT",
     install_requires=[
         "colorama",
+        "inquirer",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Implements #3 

Adds the `--search` flag which searches for a repository with a query and the GitHub repository search API.
Adds the `--lazy` flag with a simpler syntax.

## Usage

### `--search`/`-q`

```console
$ clode -q "owner:DAT516 in:name fork:true sort:updated lab 3"
[?] Select repository to clone:                                                                                  
 > DAT516/lab-3-web-application-for-tram-networks-group-59
   DAT516/lab-3-web-application-for-tram-networks-labgroup-101
   DAT516/lab3_template
```

### `--lazy`/`-l`

This performs the same search as above:

```console
$ clode -l "DAT516/lab 3"
```